### PR TITLE
Add nickname field for collaborators

### DIFF
--- a/src/components/ActivityDetailModal.tsx
+++ b/src/components/ActivityDetailModal.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Activity } from '@/hooks/useActivities';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  activity: Activity | null;
+  onValidate: (id: number, ok: boolean) => void;
+}
+
+export default function ActivityDetailModal({ open, onClose, activity, onValidate }: Props) {
+  if (!activity) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Detalle de Actividad</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm">
+              <strong>Usuario:</strong> {activity.user.name}
+            </p>
+            <p className="text-sm">
+              <strong>Tipo:</strong> {activity.exercise_type}
+            </p>
+            <p className="text-sm">
+              <strong>Duración:</strong> {activity.duration} {activity.duration_unit}
+            </p>
+            <p className="text-sm">
+              <strong>Fecha:</strong>{' '}
+              {new Date(activity.created_at).toLocaleString()}
+            </p>
+            {activity.location_lat && activity.location_lng && (
+              <p className="text-sm">
+                <strong>Ubicación:</strong> {activity.location_lat},{' '}
+                {activity.location_lng}
+              </p>
+            )}
+            {activity.notes && (
+              <p className="text-sm">
+                <strong>Notas:</strong> {activity.notes}
+              </p>
+            )}
+          </div>
+
+          {activity.selfie_url && (
+            <img
+              src={activity.selfie_url}
+              alt="Selfie"
+              className="max-h-64 w-full object-contain rounded"
+            />
+          )}
+          {activity.device_image_url && (
+            <img
+              src={activity.device_image_url}
+              alt="Dispositivo"
+              className="max-h-64 w-full object-contain rounded"
+            />
+          )}
+          {activity.attachments_url && activity.attachments_url.length > 0 && (
+            <div className="space-y-2">
+              <p className="font-medium">Adjuntos:</p>
+              <ul className="list-disc list-inside text-sm">
+                {activity.attachments_url.map(url => (
+                  <li key={url}>
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sanjer-blue underline"
+                    >
+                      {url.split('/').pop()}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button variant="destructive" onClick={() => onValidate(activity.id, false)}>
+            Rechazar
+          </Button>
+          <Button onClick={() => onValidate(activity.id, true)}>Validar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/collaborators/CollaboratorModal.tsx
+++ b/src/components/collaborators/CollaboratorModal.tsx
@@ -41,6 +41,7 @@ export const CollaboratorModal = ({
   const [formData, setFormData] = useState<Collaborator>({
     id: '',
     name: '',
+    nickname: '',
     email: '',
     phone: '',
     area: '',
@@ -70,6 +71,7 @@ export const CollaboratorModal = ({
     if (collaborator) {
       setFormData({
         ...collaborator,
+        nickname: collaborator.nickname || '',
         password: '',
         passwordConfirmation: ''
       });
@@ -78,6 +80,7 @@ export const CollaboratorModal = ({
       setFormData({
         id: '',
         name: '',
+        nickname: '',
         email: '',
         phone: '',
         area: '',
@@ -248,7 +251,18 @@ export const CollaboratorModal = ({
                     </div>
                   </div>
                 </div>
-                
+
+                <div className="space-y-2">
+                  <Label htmlFor="nickname">Nickname:</Label>
+                  <Input
+                    id="nickname"
+                    name="nickname"
+                    value={formData.nickname || ''}
+                    onChange={handleChange}
+                    placeholder="Alias opcional"
+                  />
+                </div>
+
                 <div className="space-y-2">
                   <Label htmlFor="email">Correo Electrónico:</Label>
                   <Input

--- a/src/components/collaborators/CollaboratorView.tsx
+++ b/src/components/collaborators/CollaboratorView.tsx
@@ -48,6 +48,9 @@ export const CollaboratorView = ({ isOpen, onClose, collaborator }: Collaborator
             
             <div className="flex-1">
               <h3 className="text-xl font-semibold">{collaborator.name}</h3>
+              {collaborator.nickname && (
+                <p className="text-sm text-gray-500">Alias: {collaborator.nickname}</p>
+              )}
               <p className="text-gray-500">{collaborator.email}</p>
               <p className="text-sm text-gray-500">{collaborator.occupation}</p>
               

--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -8,6 +8,18 @@ export interface Activity {
   duration: number;
   duration_unit: string;
   calories: number;
+  /** URL de selfie o evidencia */
+  selfie_url?: string | null;
+  /** Imagen del dispositivo (reloj, app, etc.) */
+  device_image_url?: string | null;
+  /** Archivos adjuntos */
+  attachments_url?: string[] | null;
+  /** Notas opcionales */
+  notes?: string | null;
+  location_lat?: number | null;
+  location_lng?: number | null;
+  /** Estado de validación: 'pendiente', 'aprobada', 'rechazada' */
+  status?: string;
   created_at: string;
 }
 
@@ -16,29 +28,34 @@ interface Paginated<T> {
   total: number;
 }
 
-export function useActivities(page = 1, userId?: number) {
-  const [data, setData]   = useState<Activity[]>([]);
+export function useActivities(
+  page = 1,
+  userId?: number,
+  search?: string
+) {
+  const [data, setData] = useState<Activity[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setLoading(true);
 
-    const url = userId
-      ? `/webadmin/users/${userId}/activities?page=${page}`
-      : `/webadmin/activities?page=${page}`;
+    const query = new URLSearchParams();
+    query.set('page', String(page));
+    if (userId) query.set('user_id', String(userId));
+    if (search) query.set('search', search);
 
-    api.get<Paginated<Activity>>(url)
-       .then(res => {
-         setData(res.data.data);
-         setTotal(res.data.total);
-       })
-       .finally(() => setLoading(false));
-  }, [page, userId]);
+    const url = `/webadmin/activities?${query.toString()}`;
 
-  return { data, total, loading, page, setPage: (p: number) => setPageState(p) };
-}
-function setPageState(p: number) {
-    throw new Error('Function not implemented.');
+    api
+      .get<Paginated<Activity>>(url)
+      .then(res => {
+        setData(res.data.data);
+        setTotal(res.data.total);
+      })
+      .finally(() => setLoading(false));
+  }, [page, userId, search]);
+
+  return { data, total, loading };
 }
 

--- a/src/pages/ManageUsers.tsx
+++ b/src/pages/ManageUsers.tsx
@@ -51,6 +51,7 @@ import { Collaborator } from '@/types/collaborator';
 interface BackendColaborator {
   id: number;
   nombre: string;
+  nickname?: string;
   telefono: string;
   area: string;
   nivel_asignado: string;
@@ -155,6 +156,7 @@ export const ManageUsers: React.FC = () => {
           return {
             id: String(col.id),
             name: col.nombre,
+            nickname: (col as any).nickname ?? '',
             email: col.user.email,
             phone: col.telefono,
             area: col.area,
@@ -312,6 +314,7 @@ export const ManageUsers: React.FC = () => {
         console.debug(`✏️ Actualizando ${c.id}`, c);
         const payload = {
           nombre: c.name,
+          nickname: c.nickname,
           sexo: (c as any).sexo,
           telefono: c.phone,
           direccion: c.address,
@@ -341,6 +344,7 @@ export const ManageUsers: React.FC = () => {
         const updated: Collaborator = {
           id: String(data.id),
           name: data.nombre,
+          nickname: (data as any).nickname ?? '',
           email: data.user.email,
           phone: data.telefono,
           area: data.area,
@@ -368,6 +372,7 @@ export const ManageUsers: React.FC = () => {
         console.debug('➕ Añadiendo…', c);
         const payload = {
           nombre: c.name,
+          nickname: c.nickname,
           email: c.email,
           password: (c as any).password,
           password_confirmation: (c as any).passwordConfirmation,
@@ -399,6 +404,7 @@ export const ManageUsers: React.FC = () => {
         const added: Collaborator = {
           id: String(data.id),
           name: data.nombre,
+          nickname: (data as any).nickname ?? '',
           email: data.user.email,
           phone: data.telefono,
           area: data.area,
@@ -755,6 +761,9 @@ export const ManageUsers: React.FC = () => {
                           </Avatar>
                           <div>
                             <div className="font-medium">{c.name}</div>
+                            {c.nickname && (
+                              <div className="text-xs text-gray-500 italic">{c.nickname}</div>
+                            )}
                             <div className="text-sm text-gray-500">{c.phone}</div>
                           </div>
                         </div>

--- a/src/types/collaborator.ts
+++ b/src/types/collaborator.ts
@@ -2,6 +2,8 @@
 export interface Collaborator {
   id: string;
   name: string;
+  /** Alias visible en rankings */
+  nickname?: string;
   email: string;
   phone: string;
   area: string;


### PR DESCRIPTION
## Summary
- allow nickname property in collaborators
- update collaborator modal and view to show nickname
- map nickname in manage users page
- show nickname in collaborators table
- expand activity table with filters and detail modal
- fetch activities with more info

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852301e11cc8328bb210ce345b7e814