### PR TITLE
Add video support and detail modal for GeneralInfo

### DIFF
--- a/src/components/GeneralInfoDetailModal.tsx
+++ b/src/components/GeneralInfoDetailModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { GeneralInfo } from '@/types/general-info';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  info: GeneralInfo | null;
+}
+
+export default function GeneralInfoDetailModal({ open, onClose, info }: Props) {
+  if (!info) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{info.title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <p className="whitespace-pre-line text-sm">{info.content}</p>
+          {info.image_url && (
+            <img
+              src={info.image_url}
+              alt="imagen"
+              className="w-full max-h-64 object-contain rounded"
+            />
+          )}
+          {info.video_url && (
+            <video
+              src={info.video_url}
+              controls
+              className="w-full max-h-64 object-contain rounded"
+            />
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose}>Cerrar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/types/general-info.ts
+++ b/src/types/general-info.ts
@@ -6,4 +6,9 @@ export interface GeneralInfo {
 
   image_path?: string | null;
 
+  video_path?: string | null;
+
+  image_url?: string | null;
+  video_url?: string | null;
+
 }


### PR DESCRIPTION
## Summary
- extend `GeneralInfo` type with video fields and urls
- add `GeneralInfoDetailModal` component to display records
- update `GeneralInfo` page to handle image/video uploads and preview
- show multimedia preview in the table and open detail modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eb8496e8883289b3f27b4c74cb76b