### PR TITLE
Implement activity validation controls

### DIFF
--- a/src/components/ActivityDetailModal.tsx
+++ b/src/components/ActivityDetailModal.tsx
@@ -41,6 +41,9 @@ export default function ActivityDetailModal({ open, onClose, activity, onValidat
               <strong>Fecha:</strong>{' '}
               {new Date(activity.created_at).toLocaleString()}
             </p>
+            <p className="text-sm">
+              <strong>Estado:</strong> {activity.is_valid ? 'Válida' : 'Inválida'}
+            </p>
             {activity.location_lat && activity.location_lng && (
               <p className="text-sm">
                 <strong>Ubicación:</strong> {activity.location_lat},{' '}
@@ -91,7 +94,7 @@ export default function ActivityDetailModal({ open, onClose, activity, onValidat
 
         <DialogFooter className="gap-2">
           <Button variant="destructive" onClick={() => onValidate(activity.id, false)}>
-            Rechazar
+            Invalidar
           </Button>
           <Button onClick={() => onValidate(activity.id, true)}>Validar</Button>
         </DialogFooter>

--- a/src/hooks/useActivities.ts
+++ b/src/hooks/useActivities.ts
@@ -20,6 +20,8 @@ export interface Activity {
   location_lng?: number | null;
   /** Estado de validación: 'pendiente', 'aprobada', 'rechazada' */
   status?: string;
+  /** Marca si la actividad se considera válida */
+  is_valid?: boolean;
   created_at: string;
 }
 
@@ -37,7 +39,7 @@ export function useActivities(
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const fetchData = () => {
     setLoading(true);
 
     const query = new URLSearchParams();
@@ -54,8 +56,10 @@ export function useActivities(
         setTotal(res.data.total);
       })
       .finally(() => setLoading(false));
-  }, [page, userId, search]);
+  };
 
-  return { data, total, loading };
+  useEffect(fetchData, [page, userId, search]);
+
+  return { data, total, loading, reload: fetchData };
 }
 


### PR DESCRIPTION
## Summary
- update useActivities hook to support `is_valid` and expose reload
- show activity validation status in detail modal
- allow validating or invalidating activities from ActivityTable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c26906e7c83289644c029bf860980